### PR TITLE
Bump Sinatra to version 1.4.8 for happier higher ruby versions support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.4.5] - 2019-03-07
+  - Bumping Sinatra to 1.4.8 to eliminate Fixnum warnings
+
+## [1.4.4] - 2018-09-14
+  - Adding the ability to view jobs by priority
+
 ## [1.4.3] - 2018-06-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [1.4.5] - 2019-03-07
-  - Bumping Sinatra to 1.4.8 to eliminate Fixnum warnings
+  - Bumping Sinatra to 1.4.8 to address Fixnum warnings
 
 ## [1.4.4] - 2018-09-14
   - Adding the ability to view jobs by priority

--- a/delayed_job_web.gemspec
+++ b/delayed_job_web.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
     "README.markdown"
   ]
 
-  gem.add_runtime_dependency "sinatra",         [">= 1.4.4"]
+  gem.add_runtime_dependency "sinatra",         [">= 1.4.8"]
   gem.add_runtime_dependency "rack-protection", [">= 1.5.5"]
   gem.add_runtime_dependency "activerecord",    ["> 3.0.0"]
   gem.add_runtime_dependency "delayed_job",     ["> 2.0.3"]

--- a/delayed_job_web.gemspec
+++ b/delayed_job_web.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name        = "delayed_job_web"
-  gem.version     = "1.4.4"
+  gem.version     = "1.4.5"
   gem.author      = "Erick Schmitt"
   gem.email       = "ejschmitt@gmail.com"
   gem.homepage    = "https://github.com/ejschmitt/delayed_job_web"


### PR DESCRIPTION
Main reason is to address the Fixnum deprecation warnings on higher versions of Ruby... 🚀 